### PR TITLE
Implement pixel stack

### DIFF
--- a/src/display/Display.h
+++ b/src/display/Display.h
@@ -6,6 +6,9 @@
 
 namespace craft {
 
+    typedef void (*drawFunc)(int x, int y, uint32_t color, int pixelScale, bool hasFramebuffer, void* buffer, int width);
+    typedef void (*blendFunc)(int x, int y, uint32_t color, float_t a, int pixelScale, bool hasFramebuffer, void* buffer, int width);
+
     /**
      * Display base class
      *
@@ -56,6 +59,16 @@ namespace craft {
          * If a framebuffer is provided these functions do not need to be implemented.
          */
         void* framebuffer = nullptr;
+
+        /**
+         * @brief The function used to draw a solid pixel
+         */
+        drawFunc drawPixel = nullptr;
+
+        /**
+         * @brief The function used to blend a pixel
+         */
+        blendFunc blendPixel = nullptr;
 
         /**
          * @brief Called at the start of a frame when drawing to the display
@@ -135,13 +148,21 @@ namespace craft {
         void _lineFlush();
 
         /**
-         * @brief Draw a pixel to the framebuffer
+         * @brief Draw or blend a pixel to the framebuffer
          *
          * @param x The x coordinate
          * @param color The color to draw
          * @param a The alpha value
          */
         void _draw(int x, uint32_t color, float_t a);
+
+        /**
+         * @brief Draw a solid pixel to the framebuffer
+         *
+         * @param x The x coordinate
+         * @param color The color to draw
+         */
+        void _drawSolid(int x, uint32_t color);
 
         /**
          * @brief Draw a pixel to the framebuffer

--- a/src/display/Pixel.h
+++ b/src/display/Pixel.h
@@ -8,36 +8,23 @@
 namespace craft {
 
     /**
-     * Stacked pixel class for blending and masking pixels during rendering (sued by Stage)
+     * Stacked pixel class for blending and masking pixels during rendering (used by Stage)
      */
-    class Pixel : public LinkedList<Pixel>, public MemoryPool<Pixel> {
+    class PixelStack {
     public:
-        color888 c = 0;
-        float_t a = 0.0;
-        bool m = false;
+        uint16_t length = 0;
+        uint16_t capacity = 0;
+        color888* c;
+        float_t* a;
+        bool solid = false;
 
-        /**
-         * @brief Recycle the pixel list
-         */
-        void recycle() override;
+        PixelStack();
 
-        /**
-         * Create a new object or take one from the pool
-         * @return The new or recycled object
-         */
-        static Pixel* Create(color888 color, float_t alpha, bool mask);
+        ~PixelStack();
 
-        /**
-         * @brief Flattens pixel list
-         * Will flatten the pixels by blending them downward, respecting masks.
-         * Will also recycle the pixels, results in an empty list
-         * @param c
-         * @return color8888
-         */
-        color8888 flatten();
+        bool push(color888 color, float_t alpha);
 
-    protected:
-        float_t _flattenMask();
+        color888 flatten(color888 base);
     };
 
 } // namespace craft

--- a/src/display/Sprite.h
+++ b/src/display/Sprite.h
@@ -98,7 +98,14 @@ namespace craft {
          * @param rx The x position in local coordinates
          * @param ry The y position in local coordinates
          */
-        void calcPixel(int16_t rx, int16_t ry);
+        void calcPixel(int16_t rx, int16_t ry) override;
+
+        /**
+         * @brief Advance position without calculating pixel
+         * @param rx The x position in local coordinates
+         * @param ry The y position in local coordinates
+         */
+        void skipPixel(int16_t rx, int16_t ry) override;
 
     protected:
         /**

--- a/src/display/Stage.h
+++ b/src/display/Stage.h
@@ -2,6 +2,7 @@
 
 #include "display/DisplayList.h"
 #include "display/Display.h"
+#include "display/Pixel.h"
 // Display object types
 #include "display/DisplayObject.h"
 #include "display/Sprite.h"

--- a/src/display/src/App.cpp
+++ b/src/display/src/App.cpp
@@ -11,7 +11,7 @@ namespace craft {
     }
 
     void App::_init() {
-        this->lastMicros = micros();
+        this->lastMicros = micros() - _renderDeltaMicrosMax;
 
         this->stage = new Stage();
         this->stage->width(this->display->_rect.width);

--- a/src/display/src/Display.cpp
+++ b/src/display/src/Display.cpp
@@ -2,6 +2,75 @@
 
 namespace craft {
 
+    // Draw funcs
+
+    void drawPixel565(int x, int _y, uint32_t c, int pixelScale, bool hasFramebuffer, void* buffer, int width) {
+        uint16_t color = to565(c);
+        uint16_t* bf = (uint16_t*)buffer;
+        x *= pixelScale;
+        int y = hasFramebuffer ? _y : 0;
+        int index = y * width + x;
+        for (int py = 0; py < pixelScale; py++) {
+            for (int px = 0; px < pixelScale; px++) {
+                bf[index + px] = color;
+            }
+            index += width;
+        }
+    }
+
+    void blendPixel565(int x, int _y, uint32_t c, float_t a, int pixelScale, bool hasFramebuffer, void* buffer, int width) {
+        uint16_t color = to565(c);
+        uint16_t* bf = (uint16_t*)buffer;
+        x *= pixelScale;
+        int y = hasFramebuffer ? _y : 0;
+        int index = y * width + x;
+        color = blend565a8(color, bf[index], a * 255);
+        for (int py = 0; py < pixelScale; py++) {
+            for (int px = 0; px < pixelScale; px++) {
+                bf[index + px] = color;
+            }
+            index += width;
+        }
+    }
+
+    void drawPixel888(int x, int _y, uint32_t color, int pixelScale, bool hasFramebuffer, void* buffer, int width) {
+        uint8_t* bf = (uint8_t*)buffer;
+        uint8_t r = red(color);
+        uint8_t g = green(color);
+        uint8_t b = blue(color);
+        x *= pixelScale;
+        int y = hasFramebuffer ? _y : 0;
+        int index = (y * width + x) * 3;
+        for (int py = 0; py < pixelScale; py++) {
+            for (int px = 0; px < pixelScale; px++) {
+                bf[index + px + 0] = r;
+                bf[index + px + 1] = g;
+                bf[index + px + 2] = b;
+            }
+            index += width * 3;
+        }
+    }
+
+    void blendPixel888(int x, int _y, uint32_t color, float_t a, int pixelScale, bool hasFramebuffer, void* buffer, int width) {
+        uint8_t* bf = (uint8_t*)buffer;
+        x *= pixelScale;
+        int y = hasFramebuffer ? _y : 0;
+        int index = (y * width + x) * 3;
+        uint32_t bg = (bf[index + 0] << 16) | (bf[index + 1] << 8) | bf[index + 2];
+        color = blend8888(color, bg, a * 255);
+        uint8_t r = red(color);
+        uint8_t g = green(color);
+        uint8_t b = blue(color);
+        for (int py = 0; py < pixelScale; py++) {
+            for (int px = 0; px < pixelScale; px++) {
+                bf[index + px + 0] = r;
+                bf[index + px + 1] = g;
+                bf[index + px + 2] = b;
+            }
+            index += width * 3;
+        }
+    }
+
     Display::~Display() {
         if (!_hasFramebuffer) {
             if (pixelFormat == PixelFormat::RGB565) {
@@ -19,11 +88,17 @@ namespace craft {
     void Display::_mount() {
         _rect.setSize((int)(width / pixelScale), (int)(height / pixelScale));
         _hasFramebuffer = framebuffer != nullptr;
-        if (!_hasFramebuffer) {
-            if (pixelFormat == PixelFormat::RGB565) {
+        if (pixelFormat == PixelFormat::RGB565) {
+            drawPixel = drawPixel565;
+            blendPixel = blendPixel565;
+            if (!_hasFramebuffer) {
                 framebuffer = new uint16_t[width * pixelScale];
             }
-            else if (pixelFormat == PixelFormat::RGB888) {
+        }
+        else if (pixelFormat == PixelFormat::RGB888) {
+            drawPixel = drawPixel888;
+            blendPixel = blendPixel888;
+            if (!_hasFramebuffer) {
                 framebuffer = new uint8_t[width * pixelScale * 3];
             }
         }
@@ -68,90 +143,16 @@ namespace craft {
      * Draw a pixel to the display
      **/
     void Display::_draw(int x, uint32_t color, float_t a) {
-        switch (pixelFormat) {
-            case PixelFormat::RGB888:
-                if (a == 1.0f) {
-                    _draw888(x, color);
-                }
-                else if (a > 0.0f) {
-                    _blend888(x, color, a);
-                }
-                break;
-            case PixelFormat::RGB565:
-            default:
-                if (a == 1.0f) {
-                    _draw565(x, to565(color));
-                }
-                else if (a > 0.0f) {
-                    _blend565(x, to565(color), a);
-                }
-                break;
+        if (a == 1.0f) {
+            drawPixel(x, _y, color, pixelScale, _hasFramebuffer, framebuffer, width);
+        }
+        else if (a > 0.0f) {
+            blendPixel(x, _y, color, a, pixelScale, _hasFramebuffer, framebuffer, width);
         }
     }
 
-    void Display::_draw565(int x, uint16_t color) {
-        uint16_t* buffer = (uint16_t*)framebuffer;
-        x *= pixelScale;
-        int y = _hasFramebuffer ? _y : 0;
-        int index = y * width + x;
-        for (int py = 0; py < pixelScale; py++) {
-            for (int px = 0; px < pixelScale; px++) {
-                buffer[index + px] = color;
-            }
-            index += width;
-        }
-    }
-
-    void Display::_blend565(int x, uint16_t color, float_t a) {
-        uint16_t* buffer = (uint16_t*)framebuffer;
-        x *= pixelScale;
-        int y = _hasFramebuffer ? _y : 0;
-        int index = y * width + x;
-        color = blend565a8(color, buffer[index], a * 255);
-        for (int py = 0; py < pixelScale; py++) {
-            for (int px = 0; px < pixelScale; px++) {
-                buffer[index + px] = color;
-            }
-            index += width;
-        }
-    }
-
-    void Display::_draw888(int x, uint32_t color) {
-        uint8_t* buffer = (uint8_t*)framebuffer;
-        uint8_t r = red(color);
-        uint8_t g = green(color);
-        uint8_t b = blue(color);
-        x *= pixelScale;
-        int y = _hasFramebuffer ? _y : 0;
-        int index = (y * width + x) * 3;
-        for (int py = 0; py < pixelScale; py++) {
-            for (int px = 0; px < pixelScale; px++) {
-                buffer[index + px + 0] = r;
-                buffer[index + px + 1] = g;
-                buffer[index + px + 2] = b;
-            }
-            index += width * 3;
-        }
-    }
-
-    void Display::_blend888(int x, uint32_t color, float_t a) {
-        uint8_t* buffer = (uint8_t*)framebuffer;
-        x *= pixelScale;
-        int y = _hasFramebuffer ? _y : 0;
-        int index = (y * width + x) * 3;
-        uint32_t bg = (buffer[index + 0] << 16) | (buffer[index + 1] << 8) | buffer[index + 2];
-        color = blend8888(color, bg, a * 255);
-        uint8_t r = red(color);
-        uint8_t g = green(color);
-        uint8_t b = blue(color);
-        for (int py = 0; py < pixelScale; py++) {
-            for (int px = 0; px < pixelScale; px++) {
-                buffer[index + px + 0] = r;
-                buffer[index + px + 1] = g;
-                buffer[index + px + 2] = b;
-            }
-            index += width * 3;
-        }
+    void Display::_drawSolid(int x, uint32_t color) {
+        drawPixel(x, _y, color, pixelScale, _hasFramebuffer, framebuffer, width);
     }
 
 } // namespace craft

--- a/src/display/src/DisplayList.cpp
+++ b/src/display/src/DisplayList.cpp
@@ -21,7 +21,7 @@ namespace craft {
      * @return int8_t >0 if a is first, <0 if b is first, 0 if equal
      */
     int compareDisplayObjectByDepth(DisplayObject* a, DisplayObject* b) {
-        return (int)b->depth - (int)a->depth;
+        return (int)a->depth - (int)b->depth;
     }
 
     /**

--- a/src/display/src/Sprite.cpp
+++ b/src/display/src/Sprite.cpp
@@ -66,6 +66,10 @@ namespace craft {
         }
     }
 
+    void Sprite::skipPixel(int16_t rx, int16_t ry) {
+        _dataOffset += _dataStep;
+    }
+
     /**
      * Ply Sprite
      */


### PR DESCRIPTION
Performance improvements:

- Implement pixel stack. As display is rendered, pixels are processed downwards only until a solid pixel is found. Any pixels below that are not visible and are skipped
- Updated pixel drawing routines to remove a couple of conditionals being checked for every pixel
- Added missing skipPixel method to Sprite (oops)